### PR TITLE
[UPDATE]

### DIFF
--- a/crypt/base64.cpp
+++ b/crypt/base64.cpp
@@ -40,7 +40,7 @@ static inline bool is_base64(unsigned char c) {
 
 std::string base64_encode(std::string const& bytes_to_encode) {
     const char* str = bytes_to_encode.c_str();
-    return base64_encode(reinterpret_cast<const unsigned char*>(str), sizeof(bytes_to_encode)-1);
+    return base64_encode(reinterpret_cast<const unsigned char*>(str), bytes_to_encode.length());
 }
 
 std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_len) {
@@ -86,7 +86,7 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 }
 
 std::string base64_decode(std::string const& encoded_string) {
-  int in_len = encoded_string.size();
+  int in_len = encoded_string.length();
   int i = 0;
   int j = 0;
   int in_ = 0;

--- a/crypt/crypt.cpp
+++ b/crypt/crypt.cpp
@@ -38,14 +38,17 @@ void Crypt::doCrypt() {
 }
 void Crypt::doDecrypt() {
     std::string decripted;
+	std::string tmpText;
     decripted = base64_decode(this->cryptedtext);
     int index;
     int stringSize = decripted.length();
     for (index = 0; index < stringSize; index++) {
         int saltIndex;
         saltIndex = index > this->salt.size() ? index % this->salt.size() : index;
-        this->cryptedtext[index] = (decripted[index] ^ this->salt[saltIndex]);
+        tmpText[index] = (decripted[index] ^ this->salt[saltIndex]);
     }
+	
+	this->cryptedtext = tmpText;
 }
 /** /
 std::cout << "\n";


### PR DESCRIPTION
- Changed the function std::string base64_encode(std::string const& bytes_to_encode) to fix the string length size. The sizeof returns the size of the variable and the variable bytes_to_encode is a pointer to String (returns 4 on a 32-bit machine and 8 on a 64-bit machine).
- Changed the function void Crypt::doDecrypt() to add a tmp variable to support the decripted value. The var this->cryptedtext has the base64 text and should be cleaned to store the new value decripted. I'm using a temp variable to prevent memory/pointer access issue.